### PR TITLE
Replace native tooltips with reservation detail popover

### DIFF
--- a/src/components/DayView.tsx
+++ b/src/components/DayView.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import React, { useRef, useEffect } from 'react';
+import React, { useRef, useEffect, useState } from 'react';
 import { ReservationWithRoom } from '@/lib/db';
+import ReservationDetailPopover from './ReservationDetailPopover';
 
 const HOUR_START = 6;
 const HOUR_END = 23;
@@ -73,6 +74,35 @@ export default function DayView({ currentDate, reservations }: Props) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const hours = Array.from({ length: TOTAL_HOURS }, (_, i) => HOUR_START + i);
   const grouped = groupOverlapping(reservations);
+  const [hovered, setHovered] = useState<{ reservation: ReservationWithRoom; rect: DOMRect } | null>(null);
+  const hideTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const showPopover = (reservation: ReservationWithRoom, el: HTMLElement) => {
+    if (hideTimeoutRef.current) {
+      clearTimeout(hideTimeoutRef.current);
+      hideTimeoutRef.current = null;
+    }
+    setHovered({ reservation, rect: el.getBoundingClientRect() });
+  };
+
+  const hidePopover = (delay = 0) => {
+    if (hideTimeoutRef.current) {
+      clearTimeout(hideTimeoutRef.current);
+      hideTimeoutRef.current = null;
+    }
+    if (delay > 0) {
+      hideTimeoutRef.current = setTimeout(() => setHovered(null), delay);
+    } else {
+      setHovered(null);
+    }
+  };
+
+  const cancelHide = () => {
+    if (hideTimeoutRef.current) {
+      clearTimeout(hideTimeoutRef.current);
+      hideTimeoutRef.current = null;
+    }
+  };
 
   const dayLabel = DAYS_KO[currentDate.getDay()];
   const isToday =
@@ -155,10 +185,11 @@ export default function DayView({ currentDate, reservations }: Props) {
               return (
                 <div
                   key={item.id}
-                  title={`${item.title}\n${item.room_name}\n${formatTime(item.start_time)} - ${formatTime(item.end_time)}\n담당: ${item.person_in_charge}${item.notes ? '\n' + item.notes : ''}${isPending ? '\n[승인 대기 중]' : ''}`}
                   className={`absolute rounded text-white text-xs px-1.5 py-1 overflow-hidden cursor-default ${
                     isPending ? 'reservation-pending opacity-80' : ''
                   }`}
+                  onMouseEnter={(e) => showPopover(item, e.currentTarget)}
+                  onMouseLeave={() => hidePopover(80)}
                   style={{
                     top,
                     height,
@@ -191,6 +222,15 @@ export default function DayView({ currentDate, reservations }: Props) {
           </div>
         </div>
       </div>
+
+      {hovered && (
+        <ReservationDetailPopover
+          reservation={hovered.reservation}
+          position={{ top: hovered.rect.top, left: hovered.rect.left }}
+          onMouseEnter={cancelHide}
+          onMouseLeave={() => hidePopover(80)}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/MonthView.tsx
+++ b/src/components/MonthView.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import React from 'react';
+import React, { useState, useRef } from 'react';
 import { ReservationWithRoom } from '@/lib/db';
+import ReservationDetailPopover from './ReservationDetailPopover';
 
 const DAYS_KO = ['일', '월', '화', '수', '목', '금', '토'];
 
@@ -52,6 +53,35 @@ export default function MonthView({ currentDate, reservations }: Props) {
   const month = currentDate.getMonth();
   const calDays = getCalendarDays(year, month);
   const today = dateKey(new Date());
+  const [hovered, setHovered] = useState<{ reservation: ReservationWithRoom; rect: DOMRect } | null>(null);
+  const hideTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const showPopover = (reservation: ReservationWithRoom, el: HTMLElement) => {
+    if (hideTimeoutRef.current) {
+      clearTimeout(hideTimeoutRef.current);
+      hideTimeoutRef.current = null;
+    }
+    setHovered({ reservation, rect: el.getBoundingClientRect() });
+  };
+
+  const hidePopover = (delay = 0) => {
+    if (hideTimeoutRef.current) {
+      clearTimeout(hideTimeoutRef.current);
+      hideTimeoutRef.current = null;
+    }
+    if (delay > 0) {
+      hideTimeoutRef.current = setTimeout(() => setHovered(null), delay);
+    } else {
+      setHovered(null);
+    }
+  };
+
+  const cancelHide = () => {
+    if (hideTimeoutRef.current) {
+      clearTimeout(hideTimeoutRef.current);
+      hideTimeoutRef.current = null;
+    }
+  };
 
   const reservationsByDay = new Map<string, ReservationWithRoom[]>();
   for (const r of reservations) {
@@ -121,14 +151,15 @@ export default function MonthView({ currentDate, reservations }: Props) {
                       return (
                         <div
                           key={r.id}
-                          title={`${r.title}\n${r.room_name}\n${formatTime(r.start_time)} - ${formatTime(r.end_time)}\n담당: ${r.person_in_charge}${isPending ? '\n[승인 대기 중]' : ''}`}
-                          className={`text-white text-xs px-1 rounded truncate leading-5 ${
+                          className={`text-white text-xs px-1 rounded truncate leading-5 cursor-default ${
                             isPending ? 'reservation-pending opacity-80' : ''
                           }`}
                           style={{
                             backgroundColor: r.room_color,
                             border: isPending ? `1px dashed ${r.room_color}` : 'none',
                           }}
+                          onMouseEnter={(e) => showPopover(r, e.currentTarget)}
+                          onMouseLeave={() => hidePopover(80)}
                         >
                           <span className="font-medium">{formatTime(r.start_time)}</span>{' '}
                           <span className="truncate">{r.title}</span>
@@ -145,6 +176,15 @@ export default function MonthView({ currentDate, reservations }: Props) {
           </div>
         ))}
       </div>
+
+      {hovered && (
+        <ReservationDetailPopover
+          reservation={hovered.reservation}
+          position={{ top: hovered.rect.top, left: hovered.rect.left }}
+          onMouseEnter={cancelHide}
+          onMouseLeave={() => hidePopover(80)}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/ReservationDetailPopover.tsx
+++ b/src/components/ReservationDetailPopover.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import React from 'react';
+import { ReservationWithRoom } from '@/lib/db';
+
+function formatTime(dateStr: string): string {
+  const d = new Date(dateStr);
+  return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
+}
+
+interface Props {
+  reservation: ReservationWithRoom;
+  /** Screen coordinates from getBoundingClientRect() */
+  position: { top: number; left: number };
+  /** Keep popover visible while hovering over it */
+  onMouseEnter?: () => void;
+  onMouseLeave?: () => void;
+}
+
+export default function ReservationDetailPopover({
+  reservation,
+  position,
+  onMouseEnter,
+  onMouseLeave,
+}: Props) {
+  const isPending = reservation.status === 'pending';
+
+  return (
+    <div
+      role="tooltip"
+      className="fixed z-[100] w-64 rounded-lg border border-gray-200 bg-white py-2.5 px-3 shadow-lg"
+      style={{
+        left: typeof window !== 'undefined' ? Math.min(position.left, window.innerWidth - 272) : position.left,
+        top: position.top,
+        transform: 'translateY(-100%) translateY(-6px)',
+      }}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+    >
+      {/* Title */}
+      <div className="font-semibold text-gray-900 text-sm mb-1.5 truncate pr-2" title={reservation.title}>
+        {reservation.title}
+      </div>
+
+      {/* Room with color swatch */}
+      <div className="flex items-center gap-1.5 text-gray-600 text-xs mb-1.5">
+        <span
+          className="shrink-0 w-2.5 h-2.5 rounded-sm border border-gray-200"
+          style={{ backgroundColor: reservation.room_color }}
+          aria-hidden
+        />
+        <span>{reservation.room_name}</span>
+      </div>
+
+      {/* Time */}
+      <div className="text-gray-600 text-xs mb-1.5">
+        {formatTime(reservation.start_time)} – {formatTime(reservation.end_time)}
+      </div>
+
+      {/* Person in charge */}
+      <div className="text-gray-600 text-xs">
+        <span className="text-gray-500">담당:</span> {reservation.person_in_charge}
+      </div>
+
+      {/* Notes */}
+      {reservation.notes && (
+        <div className="mt-1.5 pt-1.5 border-t border-gray-100">
+          <p className="text-gray-500 text-xs line-clamp-2">{reservation.notes}</p>
+        </div>
+      )}
+
+      {/* Status badge */}
+      <div className="mt-2 flex justify-end">
+        <span
+          className={`text-[10px] font-medium px-1.5 py-0.5 rounded ${
+            isPending
+              ? 'bg-amber-100 text-amber-800'
+              : 'bg-gray-100 text-gray-600'
+          }`}
+        >
+          {isPending ? '승인 대기 중' : '확정'}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/WeekView.tsx
+++ b/src/components/WeekView.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import React, { useRef, useEffect } from 'react';
+import React, { useRef, useEffect, useState } from 'react';
 import { ReservationWithRoom } from '@/lib/db';
+import ReservationDetailPopover from './ReservationDetailPopover';
 
 const HOUR_START = 6;   // 6am
 const HOUR_END = 23;    // 11pm
@@ -95,6 +96,35 @@ export default function WeekView({ weekStart, reservations }: Props) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const days = getWeekDays(weekStart);
   const today = dateKey(new Date());
+  const [hovered, setHovered] = useState<{ reservation: ReservationWithRoom; rect: DOMRect } | null>(null);
+  const hideTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const showPopover = (reservation: ReservationWithRoom, el: HTMLElement) => {
+    if (hideTimeoutRef.current) {
+      clearTimeout(hideTimeoutRef.current);
+      hideTimeoutRef.current = null;
+    }
+    setHovered({ reservation, rect: el.getBoundingClientRect() });
+  };
+
+  const hidePopover = (delay = 0) => {
+    if (hideTimeoutRef.current) {
+      clearTimeout(hideTimeoutRef.current);
+      hideTimeoutRef.current = null;
+    }
+    if (delay > 0) {
+      hideTimeoutRef.current = setTimeout(() => setHovered(null), delay);
+    } else {
+      setHovered(null);
+    }
+  };
+
+  const cancelHide = () => {
+    if (hideTimeoutRef.current) {
+      clearTimeout(hideTimeoutRef.current);
+      hideTimeoutRef.current = null;
+    }
+  };
 
   useEffect(() => {
     // Scroll to 8am on mount
@@ -196,7 +226,6 @@ export default function WeekView({ weekStart, reservations }: Props) {
                   return (
                     <div
                       key={item.id}
-                      title={`${item.title}\n${item.room_name}\n${formatTime(item.start_time)} - ${formatTime(item.end_time)}\n담당: ${item.person_in_charge}${item.notes ? '\n' + item.notes : ''}${isPending ? '\n[승인 대기 중]' : ''}`}
                       className={`absolute rounded text-white text-xs px-1 py-0.5 overflow-hidden cursor-default ${
                         isPending ? 'reservation-pending opacity-80' : ''
                       }`}
@@ -209,6 +238,8 @@ export default function WeekView({ weekStart, reservations }: Props) {
                         border: isPending ? `2px dashed ${item.room_color}` : 'none',
                         zIndex: isPending ? 1 : 2,
                       }}
+                      onMouseEnter={(e) => showPopover(item, e.currentTarget)}
+                      onMouseLeave={() => hidePopover(80)}
                     >
                       <div className="font-semibold leading-tight truncate">{item.title}</div>
                       {height > 30 && (
@@ -229,6 +260,15 @@ export default function WeekView({ weekStart, reservations }: Props) {
           })}
         </div>
       </div>
+
+      {hovered && (
+        <ReservationDetailPopover
+          reservation={hovered.reservation}
+          position={{ top: hovered.rect.top, left: hovered.rect.left }}
+          onMouseEnter={cancelHide}
+          onMouseLeave={() => hidePopover(80)}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
This PR implements #4 

## Summary
Replaces the browser `title` tooltip with a custom popover that shows reservation details when hovering over blocks in the calendar.

## Changes
- **Add** `ReservationDetailPopover` – reusable hover popover that displays:
  - Title
  - Room (with color swatch)
  - Time range
  - Person in charge (담당)
  - Notes (if any)
  - Status badge (승인 대기 중 / 확정)
- **Update** `WeekView`, `MonthView`, `DayView` – use the new popover instead of the native `title` attribute

## UX improvements
- Popover stays visible when the cursor moves from the block to the popover
- Card-style layout with clearer hierarchy
- Status badge for pending vs approved
- Notes shown when present
- Fixed positioning so the popover remains visible when scrolling

## Technical notes
- Popover is positioned above the block with a short delay before hiding
- Uses existing `ReservationWithRoom` types; no API changes