### PR TITLE
feat: recurring series support — approve/cancel by series, clearer UI

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -11,6 +11,16 @@ function formatDateTime(dt: string): string {
   return `${d.getFullYear()}.${String(d.getMonth() + 1).padStart(2, '0')}.${String(d.getDate()).padStart(2, '0')} ${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
 }
 
+/** e.g. "3/10 09:00 ~ 6/15 10:00 (12건)" for series range + count */
+/** Series range in same two-line style as single instance: earliest start, then ~ latest end (N건) */
+function formatSeriesRangeLines(reservations: ReservationWithRoom[]): { firstStart: string; lastEnd: string; count: number } | null {
+  if (reservations.length === 0) return null;
+  const byStart = [...reservations].sort((a, b) => a.start_time.localeCompare(b.start_time));
+  const firstStart = formatDateTime(byStart[0].start_time);
+  const lastEnd = formatDateTime(byStart[byStart.length - 1].end_time);
+  return { firstStart, lastEnd, count: reservations.length };
+}
+
 // ── Login Screen ──────────────────────────────────────────────────────────────
 function LoginScreen({ onSuccess }: { onSuccess: () => void }) {
   const [password, setPassword] = useState('');
@@ -146,6 +156,123 @@ function RejectModal({
   );
 }
 
+// ── Reject Series Modal ──────────────────────────────────────────────────────
+function RejectSeriesModal({
+  seriesId,
+  title,
+  roomName,
+  count,
+  onConfirm,
+  onCancel,
+}: {
+  seriesId: string;
+  title: string;
+  roomName: string;
+  count: number;
+  onConfirm: (reason: string) => void;
+  onCancel: () => void;
+}) {
+  const [reason, setReason] = useState('');
+  const [error, setError] = useState('');
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 px-4">
+      <div className="bg-white rounded-2xl shadow-xl p-6 max-w-md w-full">
+        <h3 className="text-lg font-bold text-gray-800 mb-1">반복 예약 전체 거절</h3>
+        <p className="text-sm text-gray-500 mb-4">
+          <strong className="text-gray-700">{title}</strong> — {roomName} · {count}건을 모두 거절합니다.
+        </p>
+        <div className="mb-4">
+          <label htmlFor="reject-series-reason" className="block text-sm font-medium text-gray-700 mb-1">거절 사유 <span className="text-red-500">*</span></label>
+          <textarea
+            id="reject-series-reason"
+            value={reason}
+            onChange={(e) => { setReason(e.target.value); setError(''); }}
+            placeholder="거절 사유를 입력해주세요."
+            rows={3}
+            autoFocus
+            className={`w-full border rounded-lg px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-red-400 resize-none ${
+              error ? 'border-red-400 bg-red-50' : 'border-gray-300'
+            }`}
+          />
+          {error && <p className="mt-1 text-xs text-red-500">{error}</p>}
+        </div>
+        <div className="flex gap-3">
+          <button
+            onClick={onCancel}
+            className="flex-1 px-4 py-2.5 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 text-sm transition"
+          >
+            취소
+          </button>
+          <button
+            onClick={() => {
+              if (!reason.trim()) { setError('거절 사유를 입력해주세요.'); return; }
+              onConfirm(reason.trim());
+            }}
+            className="flex-1 px-4 py-2.5 bg-red-600 hover:bg-red-700 text-white rounded-lg text-sm font-medium transition"
+          >
+            거절 확정
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Reject Cancel Series Modal (optional reason) ───────────────────────────────
+function RejectCancelSeriesModal({
+  title,
+  roomName,
+  count,
+  onConfirm,
+  onCancel,
+}: {
+  title: string;
+  roomName: string;
+  count: number;
+  onConfirm: (reason?: string) => void;
+  onCancel: () => void;
+}) {
+  const [reason, setReason] = useState('');
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 px-4">
+      <div className="bg-white rounded-2xl shadow-xl p-6 max-w-md w-full">
+        <h3 className="text-lg font-bold text-gray-800 mb-1">시리즈 취소 신청 거절</h3>
+        <p className="text-sm text-gray-500 mb-4">
+          <strong className="text-gray-700">{title}</strong> — {roomName} · {count}건의 취소 신청을 거절합니다.
+        </p>
+        <div className="mb-4">
+          <label htmlFor="reject-cancel-series-reason" className="block text-sm font-medium text-gray-700 mb-1">거절 사유 (선택, 요청자 이메일에 포함)</label>
+          <textarea
+            id="reject-cancel-series-reason"
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            placeholder="선택 사항입니다."
+            rows={3}
+            autoFocus
+            className="w-full border border-gray-300 rounded-lg px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-red-400 resize-none"
+          />
+        </div>
+        <div className="flex gap-3">
+          <button
+            onClick={onCancel}
+            className="flex-1 px-4 py-2.5 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 text-sm transition"
+          >
+            취소
+          </button>
+          <button
+            onClick={() => onConfirm(reason.trim() || undefined)}
+            className="flex-1 px-4 py-2.5 bg-red-600 hover:bg-red-700 text-white rounded-lg text-sm font-medium transition"
+          >
+            취소 거절
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 // ── Reject Cancellation Modal ─────────────────────────────────────────────────
 function RejectCancelModal({
   reservation,
@@ -244,9 +371,17 @@ function AdminPanel({ onLogout }: { onLogout: () => void }) {
   const [filter, setFilter] = useState<FilterStatus>('pending');
   const [loading, setLoading] = useState(true);
   const [rejectTarget, setRejectTarget] = useState<ReservationWithRoom | null>(null);
+  const [rejectSeriesTarget, setRejectSeriesTarget] = useState<{ seriesId: string; title: string; roomName: string; count: number } | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<ReservationWithRoom | null>(null);
   const [rejectCancelTarget, setRejectCancelTarget] = useState<ReservationWithRoom | null>(null);
+  const [rejectCancelSeriesTarget, setRejectCancelSeriesTarget] = useState<{
+    seriesId: string;
+    title: string;
+    roomName: string;
+    count: number;
+  } | null>(null);
   const [actionLoading, setActionLoading] = useState<number | null>(null);
+  const [seriesActionLoading, setSeriesActionLoading] = useState<string | null>(null);
   const [bulkLoading, setBulkLoading] = useState(false);
   const [toast, setToast] = useState<{ msg: string; type: 'success' | 'error' } | null>(null);
 
@@ -278,6 +413,45 @@ function AdminPanel({ onLogout }: { onLogout: () => void }) {
     return true;
   });
 
+  // One row per series (grouped) or per single reservation
+  type DisplayRow =
+    | { type: 'series'; seriesId: string; reservations: ReservationWithRoom[] }
+    | { type: 'single'; reservation: ReservationWithRoom };
+
+  function buildGroupedRows(): DisplayRow[] {
+    const rows: DisplayRow[] = [];
+    const seenSeries = new Set<string>();
+    for (const r of filtered) {
+      if (r.series_id) {
+        if (!seenSeries.has(r.series_id)) {
+          seenSeries.add(r.series_id);
+          const group = filtered.filter((x) => x.series_id === r.series_id);
+          // Cancellation tab: single-instance requests show as single row, not series
+          const asSingle =
+            filter === 'cancellation_requested' && group.length === 1;
+          if (asSingle) {
+            rows.push({ type: 'single', reservation: group[0] });
+          } else {
+            rows.push({ type: 'series', seriesId: r.series_id, reservations: group });
+          }
+        }
+      } else {
+        rows.push({ type: 'single', reservation: r });
+      }
+    }
+    return rows;
+  }
+
+  const pendingRows: DisplayRow[] =
+    filter === 'pending' ? buildGroupedRows() : filtered.map((r) => ({ type: 'single' as const, reservation: r }));
+  const cancellationRows: DisplayRow[] =
+    filter === 'cancellation_requested' ? buildGroupedRows() : filtered.map((r) => ({ type: 'single' as const, reservation: r }));
+
+  const displayRows: DisplayRow[] =
+    filter === 'pending' ? pendingRows : filter === 'cancellation_requested' ? cancellationRows : filtered.map((r) => ({ type: 'single' as const, reservation: r }));
+
+  const pendingSingleIds = filter === 'pending' ? filtered.filter((r) => !r.series_id).map((r) => r.id) : [];
+
   function toggleSelect(id: number) {
     setSelected((prev) => {
       const next = new Set(prev);
@@ -287,11 +461,11 @@ function AdminPanel({ onLogout }: { onLogout: () => void }) {
   }
 
   function toggleSelectAll() {
-    const pendingIds = filtered.filter((r) => r.status === 'pending').map((r) => r.id);
-    if (pendingIds.every((id) => selected.has(id))) {
+    const ids = filter === 'pending' ? pendingSingleIds : filtered.filter((r) => r.status === 'pending').map((r) => r.id);
+    if (ids.length > 0 && ids.every((id) => selected.has(id))) {
       setSelected(new Set());
     } else {
-      setSelected(new Set(pendingIds));
+      setSelected(new Set(ids));
     }
   }
 
@@ -307,6 +481,29 @@ function AdminPanel({ onLogout }: { onLogout: () => void }) {
       else { const d = await res.json(); showToast(d.error ?? '오류', 'error'); }
     } catch { showToast('네트워크 오류', 'error'); }
     finally { setActionLoading(null); }
+  }
+
+  async function handleApproveSeries(seriesId: string) {
+    setBulkLoading(true);
+    try {
+      const res = await fetch(`/api/admin/series/${encodeURIComponent(seriesId)}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'approve' }),
+      });
+      const data = await res.json();
+      if (res.ok) {
+        showToast(`${data.approved ?? 0}건 시리즈 승인 완료`);
+        setSelected(new Set());
+        fetchReservations();
+      } else {
+        showToast(data.error ?? '오류', 'error');
+      }
+    } catch {
+      showToast('네트워크 오류', 'error');
+    } finally {
+      setBulkLoading(false);
+    }
   }
 
   async function handleApproveSelected() {
@@ -346,6 +543,30 @@ function AdminPanel({ onLogout }: { onLogout: () => void }) {
       else { const d = await res.json(); showToast(d.error ?? '오류', 'error'); }
     } catch { showToast('네트워크 오류', 'error'); }
     finally { setActionLoading(null); setRejectTarget(null); }
+  }
+
+  async function handleRejectSeries(seriesId: string, reason: string) {
+    setSeriesActionLoading(seriesId);
+    try {
+      const res = await fetch(`/api/admin/series/${encodeURIComponent(seriesId)}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'reject', reason }),
+      });
+      const data = await res.json();
+      if (res.ok) {
+        showToast(`${data.rejected ?? 0}건 시리즈 거절 처리되었습니다.`);
+        fetchReservations();
+        setRejectSeriesTarget(null);
+      } else {
+        showToast(data.error ?? '오류', 'error');
+      }
+    } catch {
+      showToast('네트워크 오류', 'error');
+    } finally {
+      setSeriesActionLoading(null);
+      setRejectSeriesTarget(null);
+    }
   }
 
   async function handleDelete(id: number) {
@@ -390,6 +611,52 @@ function AdminPanel({ onLogout }: { onLogout: () => void }) {
     finally { setActionLoading(null); setRejectCancelTarget(null); }
   }
 
+  async function handleApproveCancellationSeries(seriesId: string) {
+    setSeriesActionLoading(seriesId);
+    try {
+      const res = await fetch(`/api/admin/series/${encodeURIComponent(seriesId)}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'approve_cancellation' }),
+      });
+      const data = await res.json();
+      if (res.ok) {
+        showToast(`${data.approved ?? 0}건 시리즈 취소 승인되었습니다.`);
+        fetchReservations();
+      } else {
+        showToast(data.error ?? '오류', 'error');
+      }
+    } catch {
+      showToast('네트워크 오류', 'error');
+    } finally {
+      setSeriesActionLoading(null);
+    }
+  }
+
+  async function handleRejectCancellationSeries(seriesId: string, reason?: string) {
+    setSeriesActionLoading(seriesId);
+    try {
+      const res = await fetch(`/api/admin/series/${encodeURIComponent(seriesId)}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'reject_cancellation', reason: reason ?? '' }),
+      });
+      const data = await res.json();
+      if (res.ok) {
+        showToast(`${data.rejected ?? 0}건 시리즈 취소 거절되었습니다.`);
+        fetchReservations();
+        setRejectCancelSeriesTarget(null);
+      } else {
+        showToast(data.error ?? '오류', 'error');
+      }
+    } catch {
+      showToast('네트워크 오류', 'error');
+    } finally {
+      setSeriesActionLoading(null);
+      setRejectCancelSeriesTarget(null);
+    }
+  }
+
   return (
     <div className="min-h-screen bg-gray-50">
       {/* Toast */}
@@ -409,6 +676,16 @@ function AdminPanel({ onLogout }: { onLogout: () => void }) {
           onCancel={() => setRejectTarget(null)}
         />
       )}
+      {rejectSeriesTarget && (
+        <RejectSeriesModal
+          seriesId={rejectSeriesTarget.seriesId}
+          title={rejectSeriesTarget.title}
+          roomName={rejectSeriesTarget.roomName}
+          count={rejectSeriesTarget.count}
+          onConfirm={(reason) => handleRejectSeries(rejectSeriesTarget.seriesId, reason)}
+          onCancel={() => setRejectSeriesTarget(null)}
+        />
+      )}
       {deleteTarget && (
         <DeleteModal
           reservation={deleteTarget}
@@ -421,6 +698,15 @@ function AdminPanel({ onLogout }: { onLogout: () => void }) {
           reservation={rejectCancelTarget}
           onConfirm={(reason) => handleRejectCancellation(rejectCancelTarget.id, reason)}
           onCancel={() => setRejectCancelTarget(null)}
+        />
+      )}
+      {rejectCancelSeriesTarget && (
+        <RejectCancelSeriesModal
+          title={rejectCancelSeriesTarget.title}
+          roomName={rejectCancelSeriesTarget.roomName}
+          count={rejectCancelSeriesTarget.count}
+          onConfirm={(reason) => handleRejectCancellationSeries(rejectCancelSeriesTarget.seriesId, reason)}
+          onCancel={() => setRejectCancelSeriesTarget(null)}
         />
       )}
 
@@ -516,12 +802,14 @@ function AdminPanel({ onLogout }: { onLogout: () => void }) {
                     <tr>
                       {filter === 'pending' && (
                         <th className="w-10 px-4 py-3">
-                          <input
-                            type="checkbox"
-                            checked={filtered.filter((r) => r.status === 'pending').every((r) => selected.has(r.id))}
-                            onChange={toggleSelectAll}
-                            className="rounded"
-                          />
+                          {pendingSingleIds.length > 0 && (
+                            <input
+                              type="checkbox"
+                              checked={pendingSingleIds.every((id) => selected.has(id))}
+                              onChange={toggleSelectAll}
+                              className="rounded"
+                            />
+                          )}
                         </th>
                       )}
                       <th className="text-left px-4 py-3 text-gray-600 font-medium">상태</th>
@@ -534,106 +822,277 @@ function AdminPanel({ onLogout }: { onLogout: () => void }) {
                     </tr>
                   </thead>
                   <tbody className="divide-y divide-gray-100">
-                    {filtered.map((r) => (
-                      <tr key={r.id} className={`hover:bg-gray-50 ${selected.has(r.id) ? 'bg-blue-50' : ''}`}>
-                        {filter === 'pending' && (
+                    {displayRows.map((row) =>
+                      row.type === 'series' ? (
+                        <tr key={row.seriesId} className="hover:bg-gray-50">
+                          {filter === 'pending' && <td className="px-4 py-3" />}
                           <td className="px-4 py-3">
-                            {r.status === 'pending' && (
-                              <input
-                                type="checkbox"
-                                checked={selected.has(r.id)}
-                                onChange={() => toggleSelect(r.id)}
-                                className="rounded"
-                              />
+                            <StatusBadge status={filter === 'cancellation_requested' ? 'cancellation_requested' : 'pending'} />
+                          </td>
+                          <td className="px-4 py-3 font-medium text-gray-800">
+                            <div>{row.reservations[0].title}</div>
+                            <div className="text-xs text-gray-500 mt-0.5">반복 예약 {row.reservations.length}건</div>
+                            {row.reservations[0].notes && (
+                              <div className="text-xs text-gray-400 mt-0.5 truncate max-w-xs">{row.reservations[0].notes}</div>
+                            )}
+                            {filter === 'cancellation_requested' && row.reservations[0].cancellation_reason && (
+                              <div className="text-xs text-amber-700 mt-0.5 truncate max-w-xs">취소 사유: {row.reservations[0].cancellation_reason}</div>
                             )}
                           </td>
-                        )}
-                        <td className="px-4 py-3">
-                          <StatusBadge status={r.status} />
-                        </td>
-                        <td className="px-4 py-3 font-medium text-gray-800">
-                          <div>{r.title}</div>
-                          {r.notes && <div className="text-xs text-gray-400 mt-0.5 truncate max-w-xs">{r.notes}</div>}
-                          {r.status === 'cancellation_requested' && r.cancellation_reason && (
-                            <div className="text-xs text-amber-700 mt-0.5 truncate max-w-xs">취소 사유: {r.cancellation_reason}</div>
+                          <td className="px-4 py-3">
+                            <div className="flex items-center gap-2">
+                              <span className="w-2.5 h-2.5 rounded-full flex-shrink-0" style={{ backgroundColor: row.reservations[0].room_color }} />
+                              <span className="text-gray-700">{row.reservations[0].room_name}</span>
+                            </div>
+                          </td>
+                          <td className="px-4 py-3 text-gray-600 whitespace-nowrap">
+                            {(() => {
+                              const lines = formatSeriesRangeLines(row.reservations);
+                              return lines ? (
+                                <>
+                                  <div>{lines.firstStart}</div>
+                                  <div className="text-xs text-gray-400">~ {lines.lastEnd} ({lines.count}건)</div>
+                                </>
+                              ) : null;
+                            })()}
+                          </td>
+                          <td className="px-4 py-3 text-gray-700">{row.reservations[0].person_in_charge}</td>
+                          <td className="px-4 py-3 text-xs text-gray-400 whitespace-nowrap">{formatDateTime(row.reservations[0].created_at)}</td>
+                          <td className="px-4 py-3">
+                            {filter === 'pending' ? (
+                              <div className="flex gap-1.5">
+                                <button
+                                  onClick={() => handleApproveSeries(row.seriesId)}
+                                  disabled={seriesActionLoading === row.seriesId || bulkLoading}
+                                  className="px-3 py-1.5 bg-green-600 hover:bg-green-700 disabled:opacity-50 text-white text-xs rounded-lg font-medium transition"
+                                >
+                                  {seriesActionLoading === row.seriesId ? '...' : '시리즈 승인'}
+                                </button>
+                                <button
+                                  onClick={() =>
+                                    setRejectSeriesTarget({
+                                      seriesId: row.seriesId,
+                                      title: row.reservations[0].title,
+                                      roomName: row.reservations[0].room_name,
+                                      count: row.reservations.length,
+                                    })
+                                  }
+                                  disabled={seriesActionLoading === row.seriesId || bulkLoading}
+                                  className="px-3 py-1.5 bg-red-100 hover:bg-red-200 disabled:opacity-50 text-red-700 text-xs rounded-lg font-medium transition"
+                                >
+                                  시리즈 거절
+                                </button>
+                              </div>
+                            ) : (
+                              <div className="flex gap-1.5">
+                                <button
+                                  onClick={() => handleApproveCancellationSeries(row.seriesId)}
+                                  disabled={seriesActionLoading === row.seriesId || bulkLoading}
+                                  className="px-3 py-1.5 bg-green-600 hover:bg-green-700 disabled:opacity-50 text-white text-xs rounded-lg font-medium transition"
+                                >
+                                  {seriesActionLoading === row.seriesId ? '...' : '시리즈 취소 승인'}
+                                </button>
+                                <button
+                                  onClick={() =>
+                                    setRejectCancelSeriesTarget({
+                                      seriesId: row.seriesId,
+                                      title: row.reservations[0].title,
+                                      roomName: row.reservations[0].room_name,
+                                      count: row.reservations.length,
+                                    })
+                                  }
+                                  disabled={seriesActionLoading === row.seriesId || bulkLoading}
+                                  className="px-3 py-1.5 bg-red-100 hover:bg-red-200 disabled:opacity-50 text-red-700 text-xs rounded-lg font-medium transition"
+                                >
+                                  시리즈 취소 거절
+                                </button>
+                              </div>
+                            )}
+                          </td>
+                        </tr>
+                      ) : (
+                        <tr key={row.reservation.id} className={`hover:bg-gray-50 ${selected.has(row.reservation.id) ? 'bg-blue-50' : ''}`}>
+                          {filter === 'pending' && (
+                            <td className="px-4 py-3">
+                              {row.reservation.status === 'pending' && (
+                                <input
+                                  type="checkbox"
+                                  checked={selected.has(row.reservation.id)}
+                                  onChange={() => toggleSelect(row.reservation.id)}
+                                  className="rounded"
+                                />
+                              )}
+                            </td>
                           )}
-                        </td>
-                        <td className="px-4 py-3">
-                          <div className="flex items-center gap-2">
-                            <span className="w-2.5 h-2.5 rounded-full flex-shrink-0" style={{ backgroundColor: r.room_color }} />
-                            <span className="text-gray-700">{r.room_name}</span>
-                          </div>
-                        </td>
-                        <td className="px-4 py-3 text-gray-600 whitespace-nowrap">
-                          <div>{formatDateTime(r.start_time)}</div>
-                          <div className="text-xs text-gray-400">~ {formatDateTime(r.end_time)}</div>
-                        </td>
-                        <td className="px-4 py-3 text-gray-700">{r.person_in_charge}</td>
-                        <td className="px-4 py-3 text-xs text-gray-400 whitespace-nowrap">{formatDateTime(r.created_at)}</td>
-                        <td className="px-4 py-3">
-                          <ActionButtons
-                            reservation={r}
-                            loading={actionLoading === r.id}
-                            onApprove={() => handleApprove(r.id)}
-                            onReject={() => setRejectTarget(r)}
-                            onDelete={() => setDeleteTarget(r)}
-                            onApproveCancellation={() => handleApproveCancellation(r.id)}
-                            onRejectCancellation={() => setRejectCancelTarget(r)}
-                          />
-                        </td>
-                      </tr>
-                    ))}
+                          <td className="px-4 py-3">
+                            <StatusBadge status={row.reservation.status} />
+                          </td>
+                          <td className="px-4 py-3 font-medium text-gray-800">
+                            <div>{row.reservation.title}</div>
+                            {row.reservation.notes && (
+                              <div className="text-xs text-gray-400 mt-0.5 truncate max-w-xs">{row.reservation.notes}</div>
+                            )}
+                            {row.reservation.status === 'cancellation_requested' && row.reservation.cancellation_reason && (
+                              <div className="text-xs text-amber-700 mt-0.5 truncate max-w-xs">취소 사유: {row.reservation.cancellation_reason}</div>
+                            )}
+                          </td>
+                          <td className="px-4 py-3">
+                            <div className="flex items-center gap-2">
+                              <span className="w-2.5 h-2.5 rounded-full flex-shrink-0" style={{ backgroundColor: row.reservation.room_color }} />
+                              <span className="text-gray-700">{row.reservation.room_name}</span>
+                            </div>
+                          </td>
+                          <td className="px-4 py-3 text-gray-600 whitespace-nowrap">
+                            <div>{formatDateTime(row.reservation.start_time)}</div>
+                            <div className="text-xs text-gray-400">~ {formatDateTime(row.reservation.end_time)}</div>
+                          </td>
+                          <td className="px-4 py-3 text-gray-700">{row.reservation.person_in_charge}</td>
+                          <td className="px-4 py-3 text-xs text-gray-400 whitespace-nowrap">{formatDateTime(row.reservation.created_at)}</td>
+                          <td className="px-4 py-3">
+                            <ActionButtons
+                              reservation={row.reservation}
+                              loading={actionLoading === row.reservation.id}
+                              onApprove={() => handleApprove(row.reservation.id)}
+                              onReject={() => setRejectTarget(row.reservation)}
+                              onDelete={() => setDeleteTarget(row.reservation)}
+                              onApproveCancellation={() => handleApproveCancellation(row.reservation.id)}
+                              onRejectCancellation={() => setRejectCancelTarget(row.reservation)}
+                            />
+                          </td>
+                        </tr>
+                      )
+                    )}
                   </tbody>
                 </table>
               </div>
 
               {/* Mobile cards */}
               <div className="md:hidden divide-y divide-gray-100">
-                {filtered.map((r) => (
-                  <div key={r.id} className={`p-4 ${selected.has(r.id) ? 'bg-blue-50' : ''}`}>
-                    <div className="flex items-start justify-between gap-2 mb-2">
-                      <div className="flex items-center gap-2">
-                        {filter === 'pending' && r.status === 'pending' && (
-                          <input
-                            type="checkbox"
-                            checked={selected.has(r.id)}
-                            onChange={() => toggleSelect(r.id)}
-                            className="rounded mt-0.5"
-                          />
-                        )}
-                        <StatusBadge status={r.status} />
+                {displayRows.map((row) =>
+                  row.type === 'series' ? (
+                    <div key={row.seriesId} className="p-4">
+                      <div className="flex items-start justify-between gap-2 mb-2">
+                        <StatusBadge status={filter === 'cancellation_requested' ? 'cancellation_requested' : 'pending'} />
+                        <span className="text-xs text-gray-400">{formatDateTime(row.reservations[0].created_at)}</span>
                       </div>
-                      <span className="text-xs text-gray-400">{formatDateTime(r.created_at)}</span>
+                      <p className="font-semibold text-gray-800 mb-1">{row.reservations[0].title}</p>
+                      <p className="text-xs text-gray-500 mb-1">반복 예약 {row.reservations.length}건</p>
+                      <div className="flex items-center gap-1.5 mb-1">
+                        <span className="w-2.5 h-2.5 rounded-full" style={{ backgroundColor: row.reservations[0].room_color }} />
+                        <span className="text-sm text-gray-600">{row.reservations[0].room_name}</span>
+                      </div>
+                      {(() => {
+                        const seriesLines = formatSeriesRangeLines(row.reservations);
+                        return seriesLines ? (
+                          <div className="text-xs text-gray-500 mb-1">
+                            <div>{seriesLines.firstStart}</div>
+                            <div className="text-gray-400">~ {seriesLines.lastEnd} ({seriesLines.count}건)</div>
+                          </div>
+                        ) : null;
+                      })()}
+                      <p className="text-xs text-gray-500 mb-3">담당: {row.reservations[0].person_in_charge}</p>
+                      {row.reservations[0].notes && <p className="text-xs text-gray-400 mb-3 italic">{row.reservations[0].notes}</p>}
+                      {filter === 'cancellation_requested' && row.reservations[0].cancellation_reason && (
+                        <p className="text-xs text-amber-700 mb-3">취소 사유: {row.reservations[0].cancellation_reason}</p>
+                      )}
+                      <div className="flex gap-2">
+                        {filter === 'pending' ? (
+                          <>
+                            <button
+                              onClick={() => handleApproveSeries(row.seriesId)}
+                              disabled={seriesActionLoading === row.seriesId || bulkLoading}
+                              className="px-3 py-1.5 bg-green-600 hover:bg-green-700 disabled:opacity-50 text-white text-xs rounded-lg font-medium transition"
+                            >
+                              {seriesActionLoading === row.seriesId ? '...' : '시리즈 승인'}
+                            </button>
+                            <button
+                              onClick={() =>
+                                setRejectSeriesTarget({
+                                  seriesId: row.seriesId,
+                                  title: row.reservations[0].title,
+                                  roomName: row.reservations[0].room_name,
+                                  count: row.reservations.length,
+                                })
+                              }
+                              disabled={seriesActionLoading === row.seriesId || bulkLoading}
+                              className="px-3 py-1.5 bg-red-100 hover:bg-red-200 disabled:opacity-50 text-red-700 text-xs rounded-lg font-medium transition"
+                            >
+                              시리즈 거절
+                            </button>
+                          </>
+                        ) : (
+                          <>
+                            <button
+                              onClick={() => handleApproveCancellationSeries(row.seriesId)}
+                              disabled={seriesActionLoading === row.seriesId || bulkLoading}
+                              className="px-3 py-1.5 bg-green-600 hover:bg-green-700 disabled:opacity-50 text-white text-xs rounded-lg font-medium transition"
+                            >
+                              {seriesActionLoading === row.seriesId ? '...' : '시리즈 취소 승인'}
+                            </button>
+                            <button
+                              onClick={() =>
+                                setRejectCancelSeriesTarget({
+                                  seriesId: row.seriesId,
+                                  title: row.reservations[0].title,
+                                  roomName: row.reservations[0].room_name,
+                                  count: row.reservations.length,
+                                })
+                              }
+                              disabled={seriesActionLoading === row.seriesId || bulkLoading}
+                              className="px-3 py-1.5 bg-red-100 hover:bg-red-200 disabled:opacity-50 text-red-700 text-xs rounded-lg font-medium transition"
+                            >
+                              시리즈 취소 거절
+                            </button>
+                          </>
+                        )}
+                      </div>
                     </div>
-                    <p className="font-semibold text-gray-800 mb-1">{r.title}</p>
-                    <div className="flex items-center gap-1.5 mb-1">
-                      <span className="w-2.5 h-2.5 rounded-full" style={{ backgroundColor: r.room_color }} />
-                      <span className="text-sm text-gray-600">{r.room_name}</span>
+                  ) : (
+                    <div key={row.reservation.id} className={`p-4 ${selected.has(row.reservation.id) ? 'bg-blue-50' : ''}`}>
+                      <div className="flex items-start justify-between gap-2 mb-2">
+                        <div className="flex items-center gap-2">
+                          {filter === 'pending' && row.reservation.status === 'pending' && (
+                            <input
+                              type="checkbox"
+                              checked={selected.has(row.reservation.id)}
+                              onChange={() => toggleSelect(row.reservation.id)}
+                              className="rounded mt-0.5"
+                            />
+                          )}
+                          <StatusBadge status={row.reservation.status} />
+                        </div>
+                        <span className="text-xs text-gray-400">{formatDateTime(row.reservation.created_at)}</span>
+                      </div>
+                      <p className="font-semibold text-gray-800 mb-1">{row.reservation.title}</p>
+                      <div className="flex items-center gap-1.5 mb-1">
+                        <span className="w-2.5 h-2.5 rounded-full" style={{ backgroundColor: row.reservation.room_color }} />
+                        <span className="text-sm text-gray-600">{row.reservation.room_name}</span>
+                      </div>
+                      <p className="text-xs text-gray-500 mb-1">
+                        {formatDateTime(row.reservation.start_time)} ~ {formatDateTime(row.reservation.end_time)}
+                      </p>
+                      <p className="text-xs text-gray-500 mb-3">담당: {row.reservation.person_in_charge}</p>
+                      {row.reservation.notes && <p className="text-xs text-gray-400 mb-3 italic">{row.reservation.notes}</p>}
+                      {row.reservation.status === 'cancellation_requested' && row.reservation.cancellation_reason && (
+                        <p className="text-xs text-amber-700 mb-3">취소 사유: {row.reservation.cancellation_reason}</p>
+                      )}
+                      {row.reservation.status === 'rejected' && row.reservation.rejection_reason && (
+                        <p className="text-xs text-red-500 mb-3">거절 사유: {row.reservation.rejection_reason}</p>
+                      )}
+                      <div className="flex gap-2">
+                        <ActionButtons
+                          reservation={row.reservation}
+                          loading={actionLoading === row.reservation.id}
+                          onApprove={() => handleApprove(row.reservation.id)}
+                          onReject={() => setRejectTarget(row.reservation)}
+                          onDelete={() => setDeleteTarget(row.reservation)}
+                          onApproveCancellation={() => handleApproveCancellation(row.reservation.id)}
+                          onRejectCancellation={() => setRejectCancelTarget(row.reservation)}
+                        />
+                      </div>
                     </div>
-                    <p className="text-xs text-gray-500 mb-1">
-                      {formatDateTime(r.start_time)} ~ {formatDateTime(r.end_time)}
-                    </p>
-                    <p className="text-xs text-gray-500 mb-3">담당: {r.person_in_charge}</p>
-                    {r.notes && <p className="text-xs text-gray-400 mb-3 italic">{r.notes}</p>}
-                    {r.status === 'cancellation_requested' && r.cancellation_reason && (
-                      <p className="text-xs text-amber-700 mb-3">취소 사유: {r.cancellation_reason}</p>
-                    )}
-                    {r.status === 'rejected' && r.rejection_reason && (
-                      <p className="text-xs text-red-500 mb-3">거절 사유: {r.rejection_reason}</p>
-                    )}
-                    <div className="flex gap-2">
-                      <ActionButtons
-                        reservation={r}
-                        loading={actionLoading === r.id}
-                        onApprove={() => handleApprove(r.id)}
-                        onReject={() => setRejectTarget(r)}
-                        onDelete={() => setDeleteTarget(r)}
-                        onApproveCancellation={() => handleApproveCancellation(r.id)}
-                        onRejectCancellation={() => setRejectCancelTarget(r)}
-                      />
-                    </div>
-                  </div>
-                ))}
+                  )
+                )}
               </div>
             </>
           )}

--- a/src/app/api/admin/series/[id]/route.ts
+++ b/src/app/api/admin/series/[id]/route.ts
@@ -1,0 +1,95 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  approveReservationsBySeries,
+  setReservationSeriesStatus,
+  rejectReservationsBySeries,
+  approveCancellationBySeries,
+  rejectCancellationBySeries,
+} from '@/lib/db';
+import {
+  sendBulkApprovalEmail,
+  sendRejectionEmail,
+  sendCancellationApprovedEmail,
+  sendCancellationRejectedEmail,
+} from '@/lib/email';
+import { cookies } from 'next/headers';
+import { verifyAdminSession } from '@/lib/auth';
+import { LIMITS } from '@/lib/constants';
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  if (!verifyAdminSession(cookies().get('admin_auth')?.value)) {
+    return NextResponse.json({ error: '관리자 인증이 필요합니다.' }, { status: 401 });
+  }
+
+  const seriesId = String(params.id || '').trim();
+  if (!seriesId) {
+    return NextResponse.json({ error: '잘못된 시리즈 번호입니다.' }, { status: 400 });
+  }
+
+  try {
+    const body = await req.json().catch(() => ({}));
+    const action = body?.action;
+    const reason = body?.reason?.trim();
+
+    if (action === 'approve') {
+      const approvedReservations = await approveReservationsBySeries(seriesId);
+      await setReservationSeriesStatus(seriesId, 'approved');
+
+      sendBulkApprovalEmail(approvedReservations).catch((e) =>
+        console.error('[email] 시리즈 승인 이메일 발송 실패:', e)
+      );
+
+      return NextResponse.json({ approved: approvedReservations.length });
+    }
+
+    if (action === 'reject') {
+      if (!reason) {
+        return NextResponse.json({ error: '거절 사유를 입력해주세요.' }, { status: 400 });
+      }
+      if (reason.length > LIMITS.reason) {
+        return NextResponse.json({ error: `거절 사유는 ${LIMITS.reason}자 이하여야 합니다.` }, { status: 400 });
+      }
+
+      const rejectedReservations = await rejectReservationsBySeries(seriesId, reason);
+      for (const r of rejectedReservations) {
+        sendRejectionEmail(r, reason).catch((e) =>
+          console.error('[email] 시리즈 거절 이메일 발송 실패:', e)
+        );
+      }
+      return NextResponse.json({ rejected: rejectedReservations.length });
+    }
+
+    if (action === 'approve_cancellation') {
+      const cancelled = await approveCancellationBySeries(seriesId);
+      for (const r of cancelled) {
+        sendCancellationApprovedEmail(r).catch((e) =>
+          console.error('[email] 시리즈 취소 승인 이메일 발송 실패:', e)
+        );
+      }
+      return NextResponse.json({ approved: cancelled.length });
+    }
+
+    if (action === 'reject_cancellation') {
+      const rejectReason = reason ?? undefined;
+      if (rejectReason && rejectReason.length > LIMITS.reason) {
+        return NextResponse.json({ error: `거절 사유는 ${LIMITS.reason}자 이하여야 합니다.` }, { status: 400 });
+      }
+      const reverted = await rejectCancellationBySeries(seriesId, rejectReason || null);
+      for (const r of reverted) {
+        sendCancellationRejectedEmail(r, rejectReason).catch((e) =>
+          console.error('[email] 시리즈 취소 거절 이메일 발송 실패:', e)
+        );
+      }
+      return NextResponse.json({ rejected: reverted.length });
+    }
+
+    return NextResponse.json({ error: '잘못된 요청입니다.' }, { status: 400 });
+  } catch (e) {
+    console.error(e);
+    return NextResponse.json({ error: '서버 오류' }, { status: 500 });
+  }
+}
+

--- a/src/app/api/reservations/[id]/cancel/route.ts
+++ b/src/app/api/reservations/[id]/cancel/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { requestCancellation } from '@/lib/db';
+import { getReservationById, requestCancellation, requestCancellationSeries, setReservationSeriesStatus } from '@/lib/db';
 import { checkCancelLimit } from '@/lib/ratelimit';
 import { LIMITS } from '@/lib/constants';
 
@@ -23,6 +23,7 @@ export async function POST(
 
     const body = await req.json();
     const reason = body?.reason?.trim();
+    const scope = body?.scope === 'series' ? 'series' : 'one';
     if (!reason) {
       return NextResponse.json({ error: '취소 사유를 입력해주세요.' }, { status: 400 });
     }
@@ -30,12 +31,34 @@ export async function POST(
       return NextResponse.json({ error: `취소 사유는 ${LIMITS.reason}자 이하여야 합니다.` }, { status: 400 });
     }
 
-    const ok = await requestCancellation(id, reason);
-    if (!ok) {
-      return NextResponse.json(
-        { error: '취소 신청할 수 없습니다. 대기 중이거나 확정된 예약만 취소 신청이 가능합니다.' },
-        { status: 400 }
-      );
+    if (scope === 'series') {
+      const reservation = await getReservationById(id);
+      if (!reservation) {
+        return NextResponse.json({ error: '예약 정보를 찾을 수 없습니다.' }, { status: 404 });
+      }
+      const seriesId = reservation?.series_id ?? null;
+      if (!seriesId) {
+        return NextResponse.json({ error: '반복 예약이 아닙니다.' }, { status: 400 });
+      }
+
+      const requested = await requestCancellationSeries(seriesId, reservation.start_time, reason);
+      if (requested === 0) {
+        return NextResponse.json(
+          { error: '취소 신청할 수 없습니다. 대기 중이거나 확정된 예약만 취소 신청이 가능합니다.' },
+          { status: 400 }
+        );
+      }
+
+      // Mark series as cancelled (calendar visibility is driven by instance rows)
+      await setReservationSeriesStatus(seriesId, 'cancelled');
+    } else {
+      const ok = await requestCancellation(id, reason);
+      if (!ok) {
+        return NextResponse.json(
+          { error: '취소 신청할 수 없습니다. 대기 중이거나 확정된 예약만 취소 신청이 가능합니다.' },
+          { status: 400 }
+        );
+      }
     }
 
     return NextResponse.json({ success: true });

--- a/src/app/api/reservations/route.ts
+++ b/src/app/api/reservations/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { addMonths, addDays, format } from 'date-fns';
-import { getReservations, createReservation, checkConflict, getRooms } from '@/lib/db';
+import { getReservations, createReservation, createReservationSeries, checkConflict, getRooms } from '@/lib/db';
 import { checkReservationLimit } from '@/lib/ratelimit';
 import { LIMITS } from '@/lib/constants';
 
@@ -118,18 +118,42 @@ export async function POST(req: NextRequest) {
 
     // Recurring reservation
     if (recurring && recurring !== 'none' && recurring_until) {
+      const seriesId = crypto.randomUUID();
+      await createReservationSeries({
+        id: seriesId,
+        title: titleStr,
+        room_id: roomIdNum,
+        person_in_charge: personStr,
+        email: emailStr,
+        notes: notesStr || undefined,
+        recurring,
+        recurring_until,
+      });
+
       const occurrences = generateOccurrences(start_time, end_time, recurring, recurring_until);
 
       let created = 0;
       const conflictDates: string[] = [];
+      let seriesIndex = 0;
 
       for (const occ of occurrences) {
         const hasConflict = await checkConflict(roomIdNum, occ.start_time, occ.end_time);
         if (hasConflict) {
           conflictDates.push(occ.start_time.slice(0, 10));
         } else {
-          await createReservation({ title: titleStr, room_id: roomIdNum, start_time: occ.start_time, end_time: occ.end_time, person_in_charge: personStr, email: emailStr, notes: notesStr || undefined });
+          await createReservation({
+            series_id: seriesId,
+            series_index: seriesIndex,
+            title: titleStr,
+            room_id: roomIdNum,
+            start_time: occ.start_time,
+            end_time: occ.end_time,
+            person_in_charge: personStr,
+            email: emailStr,
+            notes: notesStr || undefined,
+          });
           created++;
+          seriesIndex++;
         }
       }
 
@@ -140,7 +164,10 @@ export async function POST(req: NextRequest) {
         );
       }
 
-      return NextResponse.json({ created, conflicts: conflictDates.length, conflictDates }, { status: 201 });
+      return NextResponse.json(
+        { created, conflicts: conflictDates.length, conflictDates, seriesId },
+        { status: 201 }
+      );
     }
 
     // Single reservation

--- a/src/components/ReservationDetailPopover.tsx
+++ b/src/components/ReservationDetailPopover.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { ReservationWithRoom } from '@/lib/db';
 import { LIMITS } from '@/lib/constants';
 
@@ -32,6 +32,15 @@ export function CancelRequestModal({
   const [reason, setReason] = useState('');
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
+  const [scope, setScope] = useState<'one' | 'series'>('one');
+  const hasSeries = Boolean(reservation.series_id);
+
+  // Reset to "one instance" whenever the modal is opened with a different reservation
+  useEffect(() => {
+    setScope('one');
+    setReason('');
+    setError('');
+  }, [reservation.id]);
 
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-[110] px-4">
@@ -40,6 +49,37 @@ export function CancelRequestModal({
         <p className="text-sm text-gray-500 mb-4">
           <strong className="text-gray-700">{reservation.title}</strong> 예약의 취소를 신청합니다.
         </p>
+
+        {hasSeries && (
+          <div className="mb-4">
+            <div className="block text-sm font-medium text-gray-700 mb-1">취소 범위</div>
+            <div className="flex flex-col gap-2 text-sm">
+              <label className="flex items-center gap-2">
+                <input
+                  type="radio"
+                  name="cancel-scope"
+                  value="one"
+                  checked={scope === 'one'}
+                  onChange={() => setScope('one')}
+                  disabled={loading}
+                />
+                <span>이 일정만 취소</span>
+              </label>
+              <label className="flex items-center gap-2">
+                <input
+                  type="radio"
+                  name="cancel-scope"
+                  value="series"
+                  checked={scope === 'series'}
+                  onChange={() => setScope('series')}
+                  disabled={loading}
+                />
+                <span>이 일정부터 이후 반복 일정 모두 취소</span>
+              </label>
+            </div>
+          </div>
+        )}
+
         <div className="mb-4">
           <label htmlFor="cancel-reason" className="block text-sm font-medium text-gray-700 mb-1">취소 사유 <span className="text-red-500">*</span></label>
           <textarea
@@ -77,7 +117,7 @@ export function CancelRequestModal({
                 const res = await fetch(`/api/reservations/${reservation.id}/cancel`, {
                   method: 'POST',
                   headers: { 'Content-Type': 'application/json' },
-                  body: JSON.stringify({ reason: reason.trim() }),
+                  body: JSON.stringify({ reason: reason.trim(), scope }),
                 });
                 const data = await res.json();
                 if (res.ok) {

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -31,8 +31,26 @@ async function ensureDbReady(): Promise<void> {
     `;
 
     await sql`
+      CREATE TABLE IF NOT EXISTS reservation_series (
+        id TEXT PRIMARY KEY,
+        title TEXT NOT NULL,
+        room_id INTEGER NOT NULL REFERENCES rooms(id),
+        person_in_charge TEXT NOT NULL,
+        email TEXT NOT NULL DEFAULT '',
+        notes TEXT,
+        recurring TEXT NOT NULL,
+        recurring_until TEXT NOT NULL,
+        status TEXT NOT NULL DEFAULT 'pending',
+        rejection_reason TEXT,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+      )
+    `;
+
+    await sql`
       CREATE TABLE IF NOT EXISTS reservations (
         id                SERIAL PRIMARY KEY,
+        series_id         TEXT REFERENCES reservation_series(id),
+        series_index      INTEGER,
         title             TEXT NOT NULL,
         room_id           INTEGER NOT NULL REFERENCES rooms(id),
         start_time        TEXT NOT NULL,
@@ -51,6 +69,14 @@ async function ensureDbReady(): Promise<void> {
       await sql`ALTER TABLE reservations ADD COLUMN IF NOT EXISTS email TEXT NOT NULL DEFAULT ''`;
     } catch {
       // Column may already exist; ignore
+    }
+
+    // Series columns (idempotent)
+    try {
+      await sql`ALTER TABLE reservations ADD COLUMN IF NOT EXISTS series_id TEXT REFERENCES reservation_series(id)`;
+      await sql`ALTER TABLE reservations ADD COLUMN IF NOT EXISTS series_index INTEGER`;
+    } catch {
+      // Columns may already exist; ignore
     }
 
     // Cancellation request columns (idempotent)
@@ -110,6 +136,8 @@ export type ReservationStatus = 'pending' | 'approved' | 'rejected' | 'cancellat
 
 export interface Reservation {
   id: number;
+  series_id?: string | null;
+  series_index?: number | null;
   title: string;
   room_id: number;
   start_time: string;
@@ -128,6 +156,22 @@ export interface Reservation {
 export interface ReservationWithRoom extends Reservation {
   room_name: string;
   room_color: string;
+}
+
+export type ReservationSeriesStatus = 'pending' | 'approved' | 'rejected' | 'cancelled';
+
+export interface ReservationSeries {
+  id: string;
+  title: string;
+  room_id: number;
+  person_in_charge: string;
+  email: string;
+  notes: string | null;
+  recurring: string;
+  recurring_until: string;
+  status: ReservationSeriesStatus;
+  rejection_reason: string | null;
+  created_at: string;
 }
 
 // ---------- Queries ----------
@@ -214,6 +258,8 @@ export async function getAllReservationsForAdmin(): Promise<
 }
 
 export async function createReservation(data: {
+  series_id?: string | null;
+  series_index?: number | null;
   title: string;
   room_id: number;
   start_time: string;
@@ -224,10 +270,29 @@ export async function createReservation(data: {
 }): Promise<Reservation> {
   await ensureDbReady();
   const rows = (await getSql()`
-    INSERT INTO reservations (title, room_id, start_time, end_time, person_in_charge, email, notes)
-    VALUES (${data.title}, ${data.room_id}, ${data.start_time}, ${data.end_time}, ${data.person_in_charge}, ${data.email}, ${data.notes ?? null})
+    INSERT INTO reservations (series_id, series_index, title, room_id, start_time, end_time, person_in_charge, email, notes)
+    VALUES (${data.series_id ?? null}, ${data.series_index ?? null}, ${data.title}, ${data.room_id}, ${data.start_time}, ${data.end_time}, ${data.person_in_charge}, ${data.email}, ${data.notes ?? null})
     RETURNING *
   `) as Reservation[];
+  return rows[0];
+}
+
+export async function createReservationSeries(data: {
+  id: string;
+  title: string;
+  room_id: number;
+  person_in_charge: string;
+  email: string;
+  notes?: string;
+  recurring: string;
+  recurring_until: string;
+}): Promise<ReservationSeries> {
+  await ensureDbReady();
+  const rows = (await getSql()`
+    INSERT INTO reservation_series (id, title, room_id, person_in_charge, email, notes, recurring, recurring_until)
+    VALUES (${data.id}, ${data.title}, ${data.room_id}, ${data.person_in_charge}, ${data.email}, ${data.notes ?? null}, ${data.recurring}, ${data.recurring_until})
+    RETURNING *
+  `) as ReservationSeries[];
   return rows[0];
 }
 
@@ -273,6 +338,39 @@ export async function approveReservation(id: number): Promise<boolean> {
   return rows.length > 0;
 }
 
+export async function approveReservationsBySeries(seriesId: string): Promise<ReservationWithRoom[]> {
+  await ensureDbReady();
+  const rows = (await getSql()`
+    WITH updated AS (
+      UPDATE reservations
+      SET status = 'approved', rejection_reason = NULL
+      WHERE series_id = ${seriesId} AND status = 'pending'
+      RETURNING *
+    )
+    SELECT u.*, rm.name as room_name, rm.color as room_color
+    FROM updated u
+    JOIN rooms rm ON u.room_id = rm.id
+    ORDER BY u.start_time
+  `) as ReservationWithRoom[];
+  return rows;
+}
+
+export async function setReservationSeriesStatus(
+  seriesId: string,
+  status: ReservationSeriesStatus,
+  rejectionReason?: string | null
+): Promise<boolean> {
+  await ensureDbReady();
+  const rows = (await getSql()`
+    UPDATE reservation_series
+    SET status = ${status},
+        rejection_reason = ${rejectionReason ?? null}
+    WHERE id = ${seriesId}
+    RETURNING id
+  `) as { id: string }[];
+  return rows.length > 0;
+}
+
 export async function rejectReservation(
   id: number,
   reason: string
@@ -285,6 +383,24 @@ export async function rejectReservation(
     RETURNING id
   `) as { id: number }[];
   return rows.length > 0;
+}
+
+export async function rejectReservationsBySeries(seriesId: string, reason: string): Promise<ReservationWithRoom[]> {
+  await ensureDbReady();
+  const rows = (await getSql()`
+    WITH updated AS (
+      UPDATE reservations
+      SET status = 'rejected', rejection_reason = ${reason}
+      WHERE series_id = ${seriesId} AND status = 'pending'
+      RETURNING *
+    )
+    SELECT u.*, rm.name as room_name, rm.color as room_color
+    FROM updated u
+    JOIN rooms rm ON u.room_id = rm.id
+    ORDER BY u.start_time
+  `) as ReservationWithRoom[];
+  await setReservationSeriesStatus(seriesId, 'rejected', reason);
+  return rows;
 }
 
 export async function deleteReservation(id: number): Promise<boolean> {
@@ -314,6 +430,26 @@ export async function requestCancellation(
   return rows.length > 0;
 }
 
+export async function requestCancellationSeries(
+  seriesId: string,
+  fromStartTimeInclusive: string,
+  reason: string
+): Promise<number> {
+  await ensureDbReady();
+  const rows = (await getSql()`
+    UPDATE reservations
+    SET status = 'cancellation_requested',
+        cancellation_reason = ${reason},
+        cancellation_requested_at = now(),
+        previous_status = status
+    WHERE series_id = ${seriesId}
+      AND start_time >= ${fromStartTimeInclusive}
+      AND status IN ('pending', 'approved')
+    RETURNING id
+  `) as { id: number }[];
+  return rows.length;
+}
+
 export async function approveCancellation(id: number): Promise<boolean> {
   await ensureDbReady();
   const rows = (await getSql()`
@@ -336,4 +472,41 @@ export async function rejectCancellation(id: number): Promise<boolean> {
     RETURNING id
   `) as { id: number }[];
   return rows.length > 0;
+}
+
+export async function approveCancellationBySeries(seriesId: string): Promise<ReservationWithRoom[]> {
+  await ensureDbReady();
+  const rows = (await getSql()`
+    WITH deleted AS (
+      DELETE FROM reservations
+      WHERE series_id = ${seriesId} AND status = 'cancellation_requested'
+      RETURNING *
+    )
+    SELECT d.*, rm.name as room_name, rm.color as room_color
+    FROM deleted d
+    JOIN rooms rm ON d.room_id = rm.id
+    ORDER BY d.start_time
+  `) as ReservationWithRoom[];
+  await setReservationSeriesStatus(seriesId, 'cancelled');
+  return rows;
+}
+
+export async function rejectCancellationBySeries(seriesId: string, reason?: string | null): Promise<ReservationWithRoom[]> {
+  await ensureDbReady();
+  const rows = (await getSql()`
+    WITH updated AS (
+      UPDATE reservations
+      SET status = COALESCE(previous_status, 'approved'),
+          cancellation_reason = NULL,
+          cancellation_requested_at = NULL,
+          previous_status = NULL
+      WHERE series_id = ${seriesId} AND status = 'cancellation_requested'
+      RETURNING *
+    )
+    SELECT u.*, rm.name as room_name, rm.color as room_color
+    FROM updated u
+    JOIN rooms rm ON u.room_id = rm.id
+    ORDER BY u.start_time
+  `) as ReservationWithRoom[];
+  return rows;
 }


### PR DESCRIPTION
This PR implements #19 

## Summary
Recurring reservations are now modeled as a **series** with one row in `reservation_series` and multiple **instance** rows in `reservations` linked by `series_id`. Admins can approve or reject a whole series in one action and handle cancellation requests per series. Users can choose to cancel a single instance or the series from a given date.

---

## What's new

### For users
- **Cancel one or series**  
  When requesting cancellation on a recurring event, choose:
  - **이 일정만 취소** — only this instance
  - **이 일정부터 이후 반복 일정 모두 취소** — this instance and all future instances in the series  
  Cancel modal always opens with "이 일정만 취소" selected.

### For admins
- **승인 대기**  
  - One row per **series** (grouped by `series_id`) with **시리즈 승인** / **시리즈 거절** only (no per-instance 승인 for series).
  - Single (non-series) reservations still show one row each with **승인** / **거절** and checkboxes for bulk approve.
- **취소 신청**  
  - One row per **series** when multiple instances have cancellation requested → **시리즈 취소 승인** / **시리즈 취소 거절**.
  - When only **one** instance of a series has cancellation requested → single row with **취소 승인** / **취소 거절** (not grouped as series).
- **Series date/time**  
  - Shown in two lines, same style as single events:  
    `YYYY.MM.DD HH:mm`  
    `~ YYYY.MM.DD HH:mm (N건)`  
  - Range is chronological (earliest start → latest end).

---

## Technical details

| Area | Changes |
|------|--------|
| **DB** | New table `reservation_series`; `reservations.series_id`, `reservations.series_index` (nullable). Idempotent migrations in `ensureDbReady()`. |
| **Create recurring** | `POST /api/reservations` with `recurring` + `recurring_until`: inserts one `reservation_series` row and N instance rows with same `series_id`. |
| **Admin series API** | `PATCH /api/admin/series/[id]`: `action` in `approve`, `reject`, `approve_cancellation`, `reject_cancellation` (optional `reason` for reject). |
| **User cancel** | `POST /api/reservations/[id]/cancel`: body `{ reason, scope?: "one" \| "series" }`. `scope === "series"` uses `requestCancellationSeries` + sets series status to `cancelled`. |
| **Email** | Series approve uses existing `sendBulkApprovalEmail`; series reject and cancel approve/reject send per-instance emails. |

---

## Files touched (high level)
- `src/lib/db.ts` — `reservation_series` + series helpers (create, approve/reject by series, cancel by series).
- `src/app/api/reservations/route.ts` — recurring create writes series + instances with `series_id`.
- `src/app/api/reservations/[id]/cancel/route.ts` — `scope` one vs series.
- `src/app/api/admin/series/[id]/route.ts` — **new**; series approve/reject/approve_cancellation/reject_cancellation.
- `src/app/admin/page.tsx` — grouped rows for pending/cancellation, series vs single logic, `formatSeriesRangeLines`, series actions.
- `src/components/ReservationDetailPopover.tsx` — cancel scope UI + reset scope when modal opens.

---

## Migration / compatibility
- Existing one-off reservations remain valid (`series_id` null).
- No data migration required; new columns and table are added in place.