### PR TITLE
feat: require email verification for cancellation and send cancellation emails

### DIFF
--- a/src/app/api/reservations/[id]/cancel/route.ts
+++ b/src/app/api/reservations/[id]/cancel/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getReservationById, requestCancellation, requestCancellationSeries, setReservationSeriesStatus } from '@/lib/db';
 import { checkCancelLimit } from '@/lib/ratelimit';
 import { LIMITS } from '@/lib/constants';
+import { sendReservationCancelledEmail, sendReservationCancelledSeriesEmail } from '@/lib/email';
 
 export async function POST(
   req: NextRequest,
@@ -22,8 +23,12 @@ export async function POST(
     }
 
     const body = await req.json();
+    const email = body?.email?.trim();
     const reason = body?.reason?.trim();
     const scope = body?.scope === 'series' ? 'series' : 'one';
+    if (!email) {
+      return NextResponse.json({ error: '이메일을 입력해주세요.' }, { status: 400 });
+    }
     if (!reason) {
       return NextResponse.json({ error: '취소 사유를 입력해주세요.' }, { status: 400 });
     }
@@ -35,6 +40,9 @@ export async function POST(
       const reservation = await getReservationById(id);
       if (!reservation) {
         return NextResponse.json({ error: '예약 정보를 찾을 수 없습니다.' }, { status: 404 });
+      }
+      if (reservation.email.toLowerCase() !== email.toLowerCase()) {
+        return NextResponse.json({ error: '이메일이 일치하지 않습니다.' }, { status: 403 });
       }
       const seriesId = reservation?.series_id ?? null;
       if (!seriesId) {
@@ -51,7 +59,24 @@ export async function POST(
 
       // Mark series as cancelled (calendar visibility is driven by instance rows)
       await setReservationSeriesStatus(seriesId, 'cancelled');
+
+      sendReservationCancelledSeriesEmail({
+        title: reservation.title,
+        room_name: reservation.room_name,
+        from_start_time: reservation.start_time,
+        person_in_charge: reservation.person_in_charge,
+        email: reservation.email,
+        cancelled_count: requested,
+        cancellation_reason: reason,
+      });
     } else {
+      const reservation = await getReservationById(id);
+      if (!reservation) {
+        return NextResponse.json({ error: '예약 정보를 찾을 수 없습니다.' }, { status: 404 });
+      }
+      if (reservation.email.toLowerCase() !== email.toLowerCase()) {
+        return NextResponse.json({ error: '이메일이 일치하지 않습니다.' }, { status: 403 });
+      }
       const ok = await requestCancellation(id, reason);
       if (!ok) {
         return NextResponse.json(
@@ -59,6 +84,16 @@ export async function POST(
           { status: 400 }
         );
       }
+
+      sendReservationCancelledEmail({
+        title: reservation.title,
+        room_name: reservation.room_name,
+        start_time: reservation.start_time,
+        end_time: reservation.end_time,
+        person_in_charge: reservation.person_in_charge,
+        email: reservation.email,
+        cancellation_reason: reason,
+      });
     }
 
     return NextResponse.json({ success: true });

--- a/src/app/api/reservations/route.ts
+++ b/src/app/api/reservations/route.ts
@@ -194,6 +194,7 @@ export async function POST(req: NextRequest) {
         email: emailStr,
         occurrences: toInsert,
         created,
+        notes: notesStr || undefined,
       }).catch((e) => console.error('[email] 반복예약 확인 메일 발송 실패:', e));
 
       return NextResponse.json(
@@ -221,6 +222,7 @@ export async function POST(req: NextRequest) {
       end_time,
       person_in_charge: personStr,
       email: emailStr,
+      notes: notesStr || undefined,
     }).catch((e) => console.error('[email] 예약 확인 메일 발송 실패:', e));
 
     return NextResponse.json(reservation, { status: 201 });

--- a/src/components/ReservationDetailPopover.tsx
+++ b/src/components/ReservationDetailPopover.tsx
@@ -29,6 +29,7 @@ export function CancelRequestModal({
   onConfirm: (reason: string) => void;
   onCancel: () => void;
 }) {
+  const [email, setEmail] = useState('');
   const [reason, setReason] = useState('');
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
@@ -39,6 +40,7 @@ export function CancelRequestModal({
   // Reset to "one instance" whenever the modal is opened with a different reservation
   useEffect(() => {
     setScope('one');
+    setEmail('');
     setReason('');
     setError('');
     setSubmitted(false);
@@ -106,6 +108,22 @@ export function CancelRequestModal({
         )}
 
         <div className="mb-4">
+          <label htmlFor="cancel-email" className="block text-sm font-medium text-gray-700 mb-1">예약 시 입력한 이메일 <span className="text-red-500">*</span></label>
+          <input
+            id="cancel-email"
+            type="email"
+            value={email}
+            onChange={(e) => { setEmail(e.target.value); setError(''); }}
+            placeholder="예약에 사용한 이메일을 입력해주세요."
+            autoFocus
+            disabled={loading}
+            className={`w-full border rounded-lg px-3 py-2.5 text-base focus:outline-none focus:ring-2 focus:ring-red-400 disabled:opacity-60 ${
+              error ? 'border-red-400 bg-red-50' : 'border-gray-300'
+            }`}
+          />
+        </div>
+
+        <div className="mb-4">
           <label htmlFor="cancel-reason" className="block text-sm font-medium text-gray-700 mb-1">취소 사유 <span className="text-red-500">*</span></label>
           <textarea
             id="cancel-reason"
@@ -114,7 +132,6 @@ export function CancelRequestModal({
             placeholder="취소 사유를 입력해주세요."
             maxLength={LIMITS.reason}
             rows={3}
-            autoFocus
             disabled={loading}
             className={`w-full border rounded-lg px-3 py-2.5 text-base focus:outline-none focus:ring-2 focus:ring-red-400 resize-none disabled:opacity-60 ${
               error ? 'border-red-400 bg-red-50' : 'border-gray-300'
@@ -134,6 +151,7 @@ export function CancelRequestModal({
           <button
             type="button"
             onClick={async () => {
+              if (!email.trim()) { setError('이메일을 입력해주세요.'); return; }
               if (!reason.trim()) { setError('취소 사유를 입력해주세요.'); return; }
               if (reason.trim().length > LIMITS.reason) { setError(`취소 사유는 ${LIMITS.reason}자 이하여야 합니다.`); return; }
               setLoading(true);
@@ -142,7 +160,7 @@ export function CancelRequestModal({
                 const res = await fetch(`/api/reservations/${reservation.id}/cancel`, {
                   method: 'POST',
                   headers: { 'Content-Type': 'application/json' },
-                  body: JSON.stringify({ reason: reason.trim(), scope }),
+                  body: JSON.stringify({ email: email.trim(), reason: reason.trim(), scope }),
                 });
                 const data = await res.json();
                 if (res.ok) {

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -38,9 +38,15 @@ export async function sendReservationCreatedEmail(data: {
   end_time: string;
   person_in_charge: string;
   email: string;
+  notes?: string;
 }): Promise<void> {
   if (!process.env.GMAIL_APP_PASSWORD) return;
   const transporter = getTransporter();
+  const notesRow = data.notes ? `
+          <tr style="background:#f3f4f6;">
+            <td style="padding:8px 12px; font-weight:600;">기타 노트</td>
+            <td style="padding:8px 12px;">${escapeHtml(data.notes)}</td>
+          </tr>` : '';
   await transporter.sendMail({
     from: `"오레곤벧엘교회 장소예약시스템" <${getEmailSender()}>`,
     to: data.email,
@@ -66,7 +72,7 @@ export async function sendReservationCreatedEmail(data: {
           <tr>
             <td style="padding:8px 12px; font-weight:600;">종료</td>
             <td style="padding:8px 12px;">${formatTime(data.end_time)}</td>
-          </tr>
+          </tr>${notesRow}
         </table>
         <p style="color:#6b7280; font-size:13px;">문의사항이 있으시면 교회 사무실로 연락해 주세요.</p>
         <hr style="border:none; border-top:1px solid #e5e7eb; margin:24px 0;" />
@@ -83,6 +89,7 @@ export async function sendReservationCreatedBulkEmail(data: {
   email: string;
   occurrences: Array<{ start_time: string; end_time: string }>;
   created: number;
+  notes?: string;
 }): Promise<void> {
   if (!process.env.GMAIL_APP_PASSWORD) return;
   const transporter = getTransporter();
@@ -92,6 +99,11 @@ export async function sendReservationCreatedBulkEmail(data: {
       <td style="padding:8px 12px; border-bottom:1px solid #e5e7eb; white-space:nowrap;">${formatTime(o.end_time)}</td>
     </tr>
   `).join('');
+  const notesRow = data.notes ? `
+        <tr style="background:#f3f4f6;">
+          <td style="padding:8px 12px; font-weight:600; width:30%;">기타 노트</td>
+          <td style="padding:8px 12px;">${escapeHtml(data.notes)}</td>
+        </tr>` : '';
   await transporter.sendMail({
     from: `"오레곤벧엘교회 장소예약시스템" <${getEmailSender()}>`,
     to: data.email,
@@ -101,6 +113,7 @@ export async function sendReservationCreatedBulkEmail(data: {
         <h2 style="color: #2563eb;">반복 예약 완료 안내</h2>
         <p>안녕하세요, <strong>${escapeHtml(data.person_in_charge)}</strong>성도님.</p>
         <p><strong>${escapeHtml(data.title)}</strong> (${escapeHtml(data.room_name)}) 반복 예약 <strong style="color:#16a34a;">${data.created}건</strong>이 완료되었습니다.</p>
+        ${data.notes ? `<table style="width:100%; border-collapse:collapse; margin: 16px 0;">${notesRow}</table>` : ''}
         <table style="width:100%; border-collapse:collapse; margin: 16px 0; font-size:14px;">
           <thead>
             <tr style="background:#1e3a8a; color:white;">
@@ -255,6 +268,90 @@ export async function sendBulkApprovalEmail(reservations: ReservationWithRoom[])
       }).catch((e) => console.error('[email] 발송 실패:', e));
     }
   }
+}
+
+export async function sendReservationCancelledEmail(data: {
+  title: string;
+  room_name: string;
+  start_time: string;
+  end_time: string;
+  person_in_charge: string;
+  email: string;
+  cancellation_reason: string;
+}): Promise<void> {
+  if (!process.env.GMAIL_APP_PASSWORD) return;
+  const transporter = getTransporter();
+  await transporter.sendMail({
+    from: `"오레곤벧엘교회 장소예약시스템" <${getEmailSender()}>`,
+    to: data.email,
+    subject: `[오레곤벧엘교회] 예약이 취소되었습니다 — ${data.title}`,
+    html: `
+      <div style="font-family: sans-serif; max-width: 560px; margin: 0 auto; color: #333;">
+        <h2 style="color: #dc2626;">예약 취소 안내</h2>
+        <p>안녕하세요, <strong>${escapeHtml(data.person_in_charge)}</strong>성도님.</p>
+        <p>아래 예약이 <strong style="color: #dc2626;">취소</strong>되었습니다.</p>
+        <table style="width:100%; border-collapse:collapse; margin: 16px 0;">
+          <tr style="background:#f3f4f6;">
+            <td style="padding:8px 12px; font-weight:600; width:30%;">제목</td>
+            <td style="padding:8px 12px;">${escapeHtml(data.title)}</td>
+          </tr>
+          <tr>
+            <td style="padding:8px 12px; font-weight:600;">장소</td>
+            <td style="padding:8px 12px;">${escapeHtml(data.room_name)}</td>
+          </tr>
+          <tr style="background:#f3f4f6;">
+            <td style="padding:8px 12px; font-weight:600;">시작</td>
+            <td style="padding:8px 12px;">${formatTime(data.start_time)}</td>
+          </tr>
+          <tr>
+            <td style="padding:8px 12px; font-weight:600;">종료</td>
+            <td style="padding:8px 12px;">${formatTime(data.end_time)}</td>
+          </tr>
+          <tr style="background:#f3f4f6;">
+            <td style="padding:8px 12px; font-weight:600;">취소 사유</td>
+            <td style="padding:8px 12px;">${escapeHtml(data.cancellation_reason)}</td>
+          </tr>
+        </table>
+        <p style="color:#6b7280; font-size:13px;">문의사항이 있으시면 교회 사무실로 연락해 주세요.</p>
+        <hr style="border:none; border-top:1px solid #e5e7eb; margin:24px 0;" />
+        <p style="font-size:12px; color:#9ca3af;">오레곤벧엘교회 장소예약시스템</p>
+      </div>
+    `,
+  }).catch((e) => console.error('[email] 발송 실패:', e));
+}
+
+export async function sendReservationCancelledSeriesEmail(data: {
+  title: string;
+  room_name: string;
+  from_start_time: string;
+  person_in_charge: string;
+  email: string;
+  cancelled_count: number;
+  cancellation_reason: string;
+}): Promise<void> {
+  if (!process.env.GMAIL_APP_PASSWORD) return;
+  const transporter = getTransporter();
+  await transporter.sendMail({
+    from: `"오레곤벧엘교회 장소예약시스템" <${getEmailSender()}>`,
+    to: data.email,
+    subject: `[오레곤벧엘교회] 반복 예약 ${data.cancelled_count}건이 취소되었습니다 — ${data.title}`,
+    html: `
+      <div style="font-family: sans-serif; max-width: 560px; margin: 0 auto; color: #333;">
+        <h2 style="color: #dc2626;">반복 예약 취소 안내</h2>
+        <p>안녕하세요, <strong>${escapeHtml(data.person_in_charge)}</strong>성도님.</p>
+        <p><strong>${escapeHtml(data.title)}</strong> (${escapeHtml(data.room_name)}) 반복 예약 중 <strong>${formatTime(data.from_start_time)}</strong>부터 이후 <strong style="color: #dc2626;">${data.cancelled_count}건</strong>이 취소되었습니다.</p>
+        <table style="width:100%; border-collapse:collapse; margin: 16px 0;">
+          <tr style="background:#f3f4f6;">
+            <td style="padding:8px 12px; font-weight:600;">취소 사유</td>
+            <td style="padding:8px 12px;">${escapeHtml(data.cancellation_reason)}</td>
+          </tr>
+        </table>
+        <p style="color:#6b7280; font-size:13px;">문의사항이 있으시면 교회 사무실로 연락해 주세요.</p>
+        <hr style="border:none; border-top:1px solid #e5e7eb; margin:24px 0;" />
+        <p style="font-size:12px; color:#9ca3af;">오레곤벧엘교회 장소예약시스템</p>
+      </div>
+    `,
+  }).catch((e) => console.error('[email] 발송 실패:', e));
 }
 
 export async function sendCancellationApprovedEmail(reservation: ReservationWithRoom): Promise<void> {


### PR DESCRIPTION
## Summary
- Cancellation modal now requires the user to enter the email used when booking, reducing accidental cancellations
- Cancel API verifies the submitted email matches the reservation (case-insensitive) for both single and series cancellations, returning 403 on mismatch
- Sends a cancellation confirmation email to the user on success (separate templates for single and series)
- Adds 기타 노트 field to reservation confirmation emails (single and bulk), only rendered when notes are present

## Test plan
- [x] Submit a cancellation with the correct email — should succeed and send a confirmation email
- [x] Submit a cancellation with a wrong email — should show "이메일이 일치하지 않습니다." error
- [x] Submit a cancellation without entering an email — should show "이메일을 입력해주세요." error
- [x] Cancel a series reservation — confirm email lists the correct count and start date
- [x] Create a reservation with notes — confirm confirmation email includes 기타 노트 row
- [x] Create a reservation without notes — confirm confirmation email has no 기타 노트 row
